### PR TITLE
Replace the Ember config by a React config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tmp/**/*
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Local repositories
+/repos/*

--- a/Capfile
+++ b/Capfile
@@ -5,6 +5,8 @@ require 'capistrano/setup'
 
 # Include default deployment tasks
 require 'capistrano/deploy'
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
 
 # Include tasks from other gems included in your Gemfile, but do this in the
 # config/mixin/application/*.rb files. This way, for instance, npm recipies do

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'capistrano', '~> 3.6.1'
-gem 'capistrano-rbenv', '~> 2.0.4'
-gem 'capistrano-rails', '~> 1.1.8'
-gem 'capistrano-npm', '~> 1.0.2'
-gem 'capistrano-yarn', '~> 2.0.2'
-gem 'capistrano-bower', '~> 1.1.0'
-gem 'capistrano-ember_cli', '~> 1.0.0'
+gem 'capistrano', '~> 3.8.2'
+gem 'capistrano-rails', '~> 1.3.0'
+gem 'capistrano-rbenv', '~> 2.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    airbrussh (1.1.1)
+    airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
-    capistrano (3.6.1)
+    capistrano (3.8.2)
       airbrussh (>= 1.0.0)
-      capistrano-harrow
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bower (1.1.0)
-      capistrano (~> 3.0)
     capistrano-bundler (1.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-ember_cli (1.0.0)
-      capistrano (~> 3.0)
-    capistrano-harrow (0.5.3)
-    capistrano-npm (1.0.2)
-      capistrano (>= 3.0.0)
-    capistrano-rails (1.1.8)
+    capistrano-rails (1.3.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capistrano-rbenv (2.0.4)
+    capistrano-rbenv (2.1.1)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
-    capistrano-yarn (2.0.2)
-      capistrano (~> 3.0)
-    i18n (0.7.0)
+    i18n (0.8.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
-    rake (11.3.0)
-    sshkit (1.11.3)
+    rake (12.0.0)
+    sshkit (1.13.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
 
@@ -40,13 +30,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  capistrano (~> 3.6.1)
-  capistrano-bower (~> 1.1.0)
-  capistrano-ember_cli (~> 1.0.0)
-  capistrano-npm (~> 1.0.2)
-  capistrano-rails (~> 1.1.8)
-  capistrano-rbenv (~> 2.0.4)
-  capistrano-yarn (~> 2.0.2)
+  capistrano (~> 3.8.2)
+  capistrano-rails (~> 1.3.0)
+  capistrano-rbenv (~> 2.1.1)
 
 BUNDLED WITH
    1.14.6

--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,23 @@ Before the first deployment can succeed, the files and directories that are targ
 Which files and directories are needed to be created is specified in the `:linked_files` and `:linked_dirs` configuration variables of the corresponding application config file in [config/mixins/applications](config/mixins/applications).
 These files and directories must be located at `:deploy_to/shared/`.
 
+## Required tools and libs
+### ontohub-backend
+#### On the deploying machine
+* bundler
+#### On the server
+* rbenv
+* bundler
+
+### ontohub-frontend
+The ontohub-frontend repository is fetched to the machine that invokes capistrano and built there.
+The result (static html/css/js) is then uploaded to the server.
+Therefore, we need to install all dependencies of the ontohub-frontend on the deploying machine and nothing at all on the server.
+#### On the deploying machine
+* yarn
+#### On the server
+* nothing at all
+
 ## Structure
 
 Each allowed deployment stage is set up in [config/deploy](config/deploy) and basically consists of mixins from [config/mixins/applications](config/mixins/applications), [config/mixins/environments](config/mixins/environments) and [config/mixins/servers](config/mixins/servers).

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid only for current version of Capistrano
-lock '3.6.1'
+lock '3.8.2'
 
 # See configuration manual for options
 #   http://capistranorb.com/documentation/getting-started/configuration

--- a/config/mixins/applications/ontohub-backend.rb
+++ b/config/mixins/applications/ontohub-backend.rb
@@ -12,8 +12,11 @@ set :application, 'ontohub-backend'
 set :repo_url, 'https://github.com/ontohub/ontohub-backend.git'
 
 # Default value for :linked_files is []
-append :linked_files, 'config/database.yml', 'config/secrets.yml',
-                      'config/settings.local.yml'
+append :linked_files, 'config/database.yml',
+                      'config/secrets.yml',
+                      'config/settings.local.yml',
+                      'config/settings/production.local.yml',
+                      'config/environments/production.local.rb'
 
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'public/system', 'public/uploads',

--- a/config/mixins/applications/ontohub-frontend.rb
+++ b/config/mixins/applications/ontohub-frontend.rb
@@ -92,7 +92,8 @@ before :'deploy:publishing', :build_application do
       # Build the application and print the result
       system('yarn')
 
-      env = {'REACT_APP_BACKEND_HOST' => fetch(:backend_url)}
+      env = {'REACT_APP_BACKEND_HOST' => fetch(:backend_url),
+             'REACT_APP_GRECAPTCHA_SITE_KEY' => fetch(:grecaptcha_site_key)}
       Open3.popen2e(env, 'yarn', 'build') do |_stdin, stdout_and_err, wait_thr|
         Thread.new { stdout_and_err.each { |l| puts l } }
         wait_thr.value

--- a/config/mixins/applications/ontohub-frontend.rb
+++ b/config/mixins/applications/ontohub-frontend.rb
@@ -2,39 +2,123 @@
 
 Rake::Task['load:defaults'].invoke
 Rake::Task['load:defaults'].clear
-require 'capistrano/yarn'
-require 'capistrano/bower'
-require 'capistrano/ember_cli'
 Rake::Task['load:defaults'].reenable
 Rake::Task['load:defaults'].invoke
 
 set :application, 'ontohub-frontend'
 set :repo_url, 'https://github.com/ontohub/ontohub-frontend.git'
 
-# set :yarn_target_path, -> { release_path.join('node_modules') }
-# default without `--production` (needed for building the ember app):
-set :yarn_flags, ['--global-folder', File.join(fetch(:deploy_to), 'yarn'),
-                  '--cache-folder', File.join(fetch(:deploy_to), 'yarn-cache'),
-                  '--pure-lockfile',
-                  '--no-emoji'].join(' ')
-set :bower_bin, -> { release_path.join('node_modules/bower/bin/bower') }
-set :bower_flags, '--production --quiet --config.interactive=false'
-set :ember_cli_binary, -> { release_path.join('node_modules/.bin/ember') }
-set :ember_cli_roles, :web
-set :ember_cli_output_path, 'dist'
-# set :ember_cli_target_path, nil # defaults to the release_path
-set :ember_cli_env, :production
+set :local_repo_root, File.expand_path('../../../../repos', __FILE__)
+set :local_repo_path, File.join(fetch(:local_repo_root), fetch(:application))
+
+# We want to build this locally and push the built version to the server,
+# se we need to redefine the SCM tasks
+
+# rubocop:disable Metrics/BlockLength
+namespace :git do
+  # Clone the repo to the local directory if it is not yet cloned.
+  Rake::Task['git:clone'].clear_actions
+  task :clone do
+    run_locally do
+      `mkdir -p #{fetch(:local_repo_root).to_s}`
+      Dir.chdir(fetch(:local_repo_root).to_s) do
+        unless Dir.exist?(fetch(:local_repo_path))
+          `git clone #{fetch(:repo_url)}`
+        end
+      end
+    end
+  end
+
+  # This shall fetch the remote repo to the local directory and update it to the
+  # given branch/commit.
+  Rake::Task['git:update'].clear_actions
+  task :update do
+    run_locally do
+      Dir.chdir(fetch(:local_repo_path)) do
+        `git remote update --prune`
+      end
+    end
+  end
+
+  # This shall only create the release directory, and not push the repository at
+  # the given commit into it. Later on, the built app will be uploaded there.
+  Rake::Task['git:create_release'].clear_actions
+  task create_release: :'git:update' do
+    on release_roles :all do
+      with fetch(:git_environmental_variables) do
+        within repo_path do
+          execute :mkdir, '-p', release_path
+        end
+      end
+    end
+  end
+
+  Rake::Task['git:set_current_revision'].clear_actions
+  task :set_current_revision do
+    run_locally do
+      Dir.chdir(fetch(:local_repo_path)) do
+        current_revision = `git rev-list --max-count=1 #{fetch(:branch)}`.strip
+        set :current_revision, current_revision
+      end
+    end
+  end
+end
+
+after :'git:update', :'git:checkout' do
+  run_locally do
+    Dir.chdir(fetch(:local_repo_path)) do
+      ref = fetch(:branch)
+      # We check out a tag in a live stage - no 'origin/' required
+      if fetch(:stage).to_s.split('_', 2).first != 'live'
+        ref = "origin/#{ref}" unless ref.start_with?('origin/')
+      end
+      # Clean and reset to allow a checkout
+      `git clean -fd .`
+      `git reset --hard`
+      # Actuall checkout
+      `git checkout #{ref}`
+      # Clean again because the .gitignore might have changed and thus, the
+      # previous cleaning might be inclomplete.
+      `git clean -fd .`
+    end
+  end
+end
+
+before :'deploy:publishing', :build_application do
+  run_locally do
+    Dir.chdir(fetch(:local_repo_path)) do
+      # Build the application and print the result
+      system('yarn')
+      system('yarn', 'build')
+    end
+  end
+end
+
+after :build_application, :publish_built_application do
+  # Deploy the application
+  on roles(:all) do
+    remote_base_dir = fetch(:release_path).to_s
+    local_base_dir = File.join(fetch(:local_repo_path), 'build')
+    files = Dir.glob(File.join(local_base_dir, '**/*')).reject do |file|
+      File.directory?(file)
+    end
+    files.each do |local_file|
+      remote_file = local_file.to_s.sub(local_base_dir, remote_base_dir)
+      remote_dir = File.dirname(remote_file).sub(%r{\A~/}, '')
+      execute :mkdir, '-p', remote_dir
+      upload! local_file, remote_dir
+    end
+  end
+end
 
 after :'deploy:publishing', :create_symlinks do
   on roles(:all) do
     execute('ln', '-sf',
-            File.join(fetch(:deploy_to), 'current',
-              fetch(:ember_cli_output_path)),
+            File.join(fetch(:deploy_to), 'current'),
             File.join(fetch(:deploy_to), 'webapp'))
 
     execute('ln', '-sf',
-            File.join(fetch(:deploy_to), 'current',
-              fetch(:ember_cli_output_path)),
+            File.join(fetch(:deploy_to), 'current'),
             File.join("~#{fetch(:deploy_user)}", 'public', 'html'))
   end
 end

--- a/config/mixins/servers/staging.ontohub.org.rb
+++ b/config/mixins/servers/staging.ontohub.org.rb
@@ -6,3 +6,4 @@ set :tmp_dir, '/var/tmp'
 set :rbenv_custom_path, '/local/usr/ruby'
 
 set :branch, 'master'
+set :backend_url, 'https://tb.iks.cs.ovgu.de'

--- a/config/mixins/servers/staging.ontohub.org.rb
+++ b/config/mixins/servers/staging.ontohub.org.rb
@@ -7,3 +7,4 @@ set :rbenv_custom_path, '/local/usr/ruby'
 
 set :branch, 'master'
 set :backend_url, 'https://tb.iks.cs.ovgu.de'
+set :grecaptcha_site_key, '6LdKSR8UAAAAANuiYuJcuJRQm4Go-dQh0he82vpU'


### PR DESCRIPTION
This allows us to deploy the react frontend. The ontohub-frontend repository is cloned to the local machine, the correct branch is checked out there and then it's built locally. We don't have any dependencies on the server for the frontend.

Unfortunately, we need to override some of the git tasks for this, but it's for a good cause.