### PR TITLE
12 deploy api documentation

### DIFF
--- a/config/mixins/applications/apidoc.rb
+++ b/config/mixins/applications/apidoc.rb
@@ -75,3 +75,10 @@ before :'deploy:publishing', :build_application do
 end
 
 after :build_application, :publish_built_application
+
+after :publish_built_application, :remove_unnecessary_directories do
+  on roles(:all) do
+    execute(:rmdir, File.join(fetch(:deploy_to), 'repo'))
+    execute(:rmdir, File.join(fetch(:deploy_to), 'shared'))
+  end
+end

--- a/config/mixins/servers/staging.ontohub.org.rb
+++ b/config/mixins/servers/staging.ontohub.org.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
+# Machine configuration
 set :deploy_user, 'webadm'
 server 'staging.ontohub.org', user: fetch(:deploy_user), roles: %w(app db web)
 set :tmp_dir, '/var/tmp'
 set :rbenv_custom_path, '/local/usr/ruby'
 
 set :branch, 'master'
+
+# Frontend configuration
 set :backend_url, 'https://tb.iks.cs.ovgu.de'
 set :grecaptcha_site_key, '6LdKSR8UAAAAANuiYuJcuJRQm4Go-dQh0he82vpU'
 
+# APIdoc configuration
+set :apidoc_dir, 'staging'
+
+# Local repository targets
 after :'git:update', :set_latest_tag {}
 after :set_latest_tag, :set_deploy_tag {}

--- a/tasks/deploy_symlink_release.rake
+++ b/tasks/deploy_symlink_release.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Rake::Task['deploy:symlink:release'].clear_actions
+
+namespace :deploy do
+  namespace :symlink do
+    desc 'Symlink release to current'
+    # This overwrites the default capistrano task to create a relative symlink.
+    task :release do
+      on release_roles :all do
+        within deploy_path do
+          current = current_path.sub(%r{\A#{deploy_path}/?}, '')
+          release = release_path.sub(%r{\A#{deploy_path}/?}, '')
+          execute :ln, '-sf', release, current
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This shall fix #12 such that it gets properly deployed to http://docs.ontohub.org. 

It properly sets up directories and symlinks. It also removes the empty directories that capistrano sets up in the end. Shall I remove the `revisions.log` as well?